### PR TITLE
Add missing Xslt 2.0 and 3.0 starting content

### DIFF
--- a/src/utils/integration-account/mapUtils.ts
+++ b/src/utils/integration-account/mapUtils.ts
@@ -22,9 +22,15 @@ export async function createNewMap(mapName: string, mapType: MapType): Promise<I
         case MapType.Liquid:
             content = "{% if user %}\nHello {{ user.name }}\n{% endif %}";
             break;
+        case MapType.Xslt30:
+            content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xsl:stylesheet version=\"3.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n\t<xsl:template match=\"/\">\n\n\t</xsl:template>\n</xsl:stylesheet>";
+            break;
+        case MapType.Xslt20:
+            content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xsl:stylesheet version=\"2.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n\t<xsl:template match=\"/\">\n\n\t</xsl:template>\n</xsl:stylesheet>";
+            break;
         case MapType.Xslt:
         default:
-            content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xsl:stylesheet version=\"1.0\"\nxmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n<xsl:template match=\"/\">\n\n</xsl:template>\n</xsl:stylesheet>";
+            content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n\t<xsl:template match=\"/\">\n\n\t</xsl:template>\n</xsl:stylesheet>";
     }
 
     const map: IntegrationAccountMap = {


### PR DESCRIPTION
DIdn't add in the initial content for the other types back during the original development since the SDK didn't support them. This adds them in to fix #30