### PR TITLE
Fix "command 'azureLogicApps.createLogicApp' not found" error

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ],
     "preview": true,
     "activationEvents": [
-        "onCommand:azureLogicApps.createLogicApps",
+        "onCommand:azureLogicApps.createLogicApp",
         "onCommand:azureLogicApps.deleteLogicApp",
         "onCommand:azureLogicApps.disableLogicApp",
         "onCommand:azureLogicApps.enableLogicApp",


### PR DESCRIPTION
- Fix #43