### PR TITLE
Fix the workflow with IA workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -245,9 +245,9 @@
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
         },
         "azure-arm-logic": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/azure-arm-logic/-/azure-arm-logic-4.1.0.tgz",
-            "integrity": "sha512-YMYg0ILWFF/a4zRJjZUQATwDqdtzHL0Ys3eGcxpEs/7wmc1G8zYXTAavJgbAQEnmlEp2tHF3KQSAF4YucWIu6w==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/azure-arm-logic/-/azure-arm-logic-4.2.0.tgz",
+            "integrity": "sha512-YJGAVIyQ4/tj+Hj/QoQy3HSq5LfLGu8Mx6MgNMJt9kGqrgfkNAJK5hDZh8RpkitCYEZs4zjUUJvevdi6dFvVOQ==",
             "requires": {
                 "ms-rest": "^2.3.3",
                 "ms-rest-azure": "^2.5.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,9 +245,9 @@
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
         },
         "azure-arm-logic": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/azure-arm-logic/-/azure-arm-logic-4.0.0.tgz",
-            "integrity": "sha512-+scdY3FDlssOLL/wYa/3JvLbXxR5l1u9BhF7FqEPe44LeGIWfPtEAWofLx3GgNaADNZIZo5t8xlNmXWxaXalaw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/azure-arm-logic/-/azure-arm-logic-4.1.0.tgz",
+            "integrity": "sha512-YMYg0ILWFF/a4zRJjZUQATwDqdtzHL0Ys3eGcxpEs/7wmc1G8zYXTAavJgbAQEnmlEp2tHF3KQSAF4YucWIu6w==",
             "requires": {
                 "ms-rest": "^2.3.3",
                 "ms-rest-azure": "^2.5.5"

--- a/package.json
+++ b/package.json
@@ -603,7 +603,7 @@
         "vscode": "^1.1.18"
     },
     "dependencies": {
-        "azure-arm-logic": "^4.0.0",
+        "azure-arm-logic": "^4.1.0",
         "request": "^2.88.0",
         "request-promise-native": "^1.0.5",
         "vscode-azureextensionui": "^0.16.4",

--- a/package.json
+++ b/package.json
@@ -603,7 +603,7 @@
         "vscode": "^1.1.18"
     },
     "dependencies": {
-        "azure-arm-logic": "^4.1.0",
+        "azure-arm-logic": "^4.2.0",
         "request": "^2.88.0",
         "request-promise-native": "^1.0.5",
         "vscode-azureextensionui": "^0.16.4",


### PR DESCRIPTION
Update the Logic App SDK so that we can remove the workaround for workflows that have an attached integration account not being able to be updated