### PR TITLE
Avoid save prompt when closing the editor for preview content

### DIFF
--- a/src/commands/logic-app/openRunActionInEditor.ts
+++ b/src/commands/logic-app/openRunActionInEditor.ts
@@ -5,7 +5,7 @@
 
 import { AzureTreeDataProvider, IAzureNode } from "vscode-azureextensionui";
 import { LogicAppRunActionTreeItem } from "../../tree/logic-app/LogicAppRunActionTreeItem";
-import { openAndShowTextDocument } from "../../utils/commandUtils";
+import { openReadOnlyJson } from "../../utils/readOnlyUtils";
 
 export async function openRunActionInEditor(tree: AzureTreeDataProvider, node?: IAzureNode): Promise<void> {
     if (!node) {
@@ -13,5 +13,5 @@ export async function openRunActionInEditor(tree: AzureTreeDataProvider, node?: 
     }
 
     const content = await (node.treeItem as LogicAppRunActionTreeItem).getData();
-    await openAndShowTextDocument(content);
+    await openReadOnlyJson(node.id, content);
 }

--- a/src/commands/logic-app/openRunInEditor.ts
+++ b/src/commands/logic-app/openRunInEditor.ts
@@ -5,7 +5,7 @@
 
 import { AzureTreeDataProvider, IAzureNode } from "vscode-azureextensionui";
 import { LogicAppRunTreeItem } from "../../tree/logic-app/LogicAppRunTreeItem";
-import { openAndShowTextDocument } from "../../utils/commandUtils";
+import { openReadOnlyJson } from "../../utils/readOnlyUtils";
 
 export async function openRunInEditor(tree: AzureTreeDataProvider, node?: IAzureNode): Promise<void> {
     if (!node) {
@@ -13,5 +13,5 @@ export async function openRunInEditor(tree: AzureTreeDataProvider, node?: IAzure
     }
 
     const content = await (node.treeItem as LogicAppRunTreeItem).getData();
-    await openAndShowTextDocument(content);
+    await openReadOnlyJson(node.id, content);
 }

--- a/src/commands/logic-app/openTriggerInEditor.ts
+++ b/src/commands/logic-app/openTriggerInEditor.ts
@@ -5,7 +5,7 @@
 
 import { AzureTreeDataProvider, IAzureNode } from "vscode-azureextensionui";
 import { LogicAppTriggerTreeItem } from "../../tree/logic-app/LogicAppTriggerTreeItem";
-import { openAndShowTextDocument } from "../../utils/commandUtils";
+import { openReadOnlyJson } from "../../utils/readOnlyUtils";
 
 export async function openTriggerInEditor(tree: AzureTreeDataProvider, node?: IAzureNode): Promise<void> {
     if (!node) {
@@ -13,5 +13,5 @@ export async function openTriggerInEditor(tree: AzureTreeDataProvider, node?: IA
     }
 
     const content = await (node.treeItem as LogicAppTriggerTreeItem).getData();
-    await openAndShowTextDocument(content);
+    await openReadOnlyJson(node.id, content);
 }

--- a/src/commands/logic-app/openVersionInEditor.ts
+++ b/src/commands/logic-app/openVersionInEditor.ts
@@ -6,7 +6,7 @@
 import { AzureTreeDataProvider, IAzureNode } from "vscode-azureextensionui";
 import { LogicAppCurrentVersionTreeItem } from "../../tree/logic-app/LogicAppCurrentVersionTreeItem";
 import { LogicAppVersionTreeItem } from "../../tree/logic-app/LogicAppVersionTreeItem";
-import { openAndShowTextDocument } from "../../utils/commandUtils";
+import { openReadOnlyJson } from "../../utils/readOnlyUtils";
 
 export async function openVersionInEditor(tree: AzureTreeDataProvider, node?: IAzureNode): Promise<void> {
     if (!node) {
@@ -14,5 +14,5 @@ export async function openVersionInEditor(tree: AzureTreeDataProvider, node?: IA
     }
 
     const content = await (node.treeItem as LogicAppCurrentVersionTreeItem | LogicAppVersionTreeItem).getData();
-    await openAndShowTextDocument(content);
+    await openReadOnlyJson(node.id, content);
 }

--- a/src/utils/readOnlyUtils.ts
+++ b/src/utils/readOnlyUtils.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+    This functionality is more or less "cherry-picked" from package "vscode-azureextensionui".
+    Currently we can not use it from there due to the fact that we depend on an old version.
+    Once we move to a more recent version we should eventually remove this file and rewire the
+    call sites to the "genuine" implementation.
+*/
+
+import { createHash } from "crypto";
+import { isNullOrUndefined } from "util";
+import { CancellationToken, Event, EventEmitter, TextDocumentContentProvider, Uri, window, workspace } from "vscode";
+import { ext } from "../extensionVariables";
+
+let contentProvider: ReadOnlyContentProvider | undefined;
+const providerScheme = "azurelogicappsReadonly";
+
+export async function openReadOnlyJson(name: string, content: string) {
+    return openReadOnlyContent(name, content, ".json");
+}
+
+export async function openReadOnlyContent(name: string, content: string, fileExt: string) {
+    if (!contentProvider) {
+        contentProvider = new ReadOnlyContentProvider();
+        ext.context.subscriptions.push(
+            workspace.registerTextDocumentContentProvider(providerScheme, contentProvider));
+    }
+    await contentProvider.openReadOnlyContent(name, content, fileExt);
+}
+
+class ReadOnlyContentProvider implements TextDocumentContentProvider {
+    private _onDidChangeEmitter = new EventEmitter<Uri>();
+    private _contentMap = new Map<string, string>();
+
+    public get onDidChange(): Event<Uri> {
+        return this._onDidChangeEmitter.event;
+    }
+
+    public async openReadOnlyContent(name: string, content: string, fileExt: string): Promise<void> {
+        const nameHash = createHash("sha256").update(name).digest("hex");
+        const uri = Uri.parse(`${providerScheme}:///${nameHash}/${name}${fileExt}`);
+        this._contentMap.set(uri.toString(), content);
+        await window.showTextDocument(uri);
+        this._onDidChangeEmitter.fire(uri);
+    }
+
+    public async provideTextDocumentContent(uri: Uri, _token: CancellationToken): Promise<string> {
+        let content = this._contentMap.get(uri.toString());
+        if (isNullOrUndefined(content)) {
+            throw new Error(
+                "Internal error: Expected content from read-only provider to be neither null nor undefined");
+        }
+        return content;
+    }
+}


### PR DESCRIPTION
Currently 'untitled' files are opened when viewing a run, action, trigger or version of a Logic App which causes a save prompt when closing the corresponding editor.
This PR introduces an own content provider for showing read-only files to solve the issue above.

The PR's functionality is more or less 'cherry-picked' from [microsoft/vscode-azuretools](https://github.com/microsoft/vscode-azuretools) as we currently depend on an old version of the package which does not contain the required functionality and updating to a more recent version of it would cause a lot of refactoring. Once we update the dependency to a version which includes the read-only content provider, we should remove this PR's read-only content provider and rewire its callers to use the 'genuine' implementation.

See also #107