### PR TITLE
Fix #133 - Azure Environment Selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6228,9 +6228,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.16.6",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.16.6.tgz",
-            "integrity": "sha512-vb5PdCprfqfjy3gMrtiwRyf9Q2L5CqJJA4BAwVyfwMHEp4IZ9Co0nsgi+AIzCvqyvlBtwGG9HIsCm+vMhPtHww==",
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.17.1.tgz",
+            "integrity": "sha512-K7UyoMgIhXf277Asowlc/5XW2ilMbFB55B1Ga9DJNk0ragBY4gsOHNfiYzZsACOcvFmN8pa9YpD/A437pp099w==",
             "requires": {
                 "azure-arm-resource": "^3.0.0-preview",
                 "azure-arm-storage": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -769,7 +769,7 @@
         "lodash": "^4.17.15",
         "request": "^2.88.2",
         "request-promise-native": "^1.0.8",
-        "vscode-azureextensionui": "^0.16.5",
+        "vscode-azureextensionui": "0.17.1",
         "vscode-extension-telemetry": "0.0.18",
         "vscode-nls": "^3.2.5"
     },

--- a/src/tree/integration-account/IntegrationAccountsProvider.ts
+++ b/src/tree/integration-account/IntegrationAccountsProvider.ts
@@ -24,7 +24,7 @@ export class IntegrationAccountProvider implements IChildProvider {
             this.nextLink = undefined;
         }
 
-        const client = new LogicAppsManagementClient(node.credentials, node.subscriptionId);
+        const client = new LogicAppsManagementClient(node.credentials, node.subscriptionId, node.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         const integrationAccounts = this.nextLink === undefined

--- a/src/tree/logic-app/LogicAppsProvider.ts
+++ b/src/tree/logic-app/LogicAppsProvider.ts
@@ -28,7 +28,7 @@ export class LogicAppsProvider implements IChildProvider {
             this.nextLink = undefined;
         }
 
-        const client = new LogicAppsManagementClient(node.credentials, node.subscriptionId);
+        const client = new LogicAppsManagementClient(node.credentials, node.subscriptionId, node.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         const logicApps = this.nextLink === undefined

--- a/src/utils/integration-account/partnerUtils.ts
+++ b/src/utils/integration-account/partnerUtils.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzureEnvironment } from "ms-rest-azure";
 import LogicAppsManagementClient from "azure-arm-logic";
 import { IntegrationAccountPartner } from "azure-arm-logic/lib/models";
 import { ServiceClientCredentials } from "ms-rest";
@@ -31,8 +32,8 @@ export async function createNewPartner(partnerName: string, qualifier: string, v
     return partner;
 }
 
-export async function getAllPartners(credentials: ServiceClientCredentials, subscriptionId: string, resourceGroup: string, integrationAccount: string): Promise<IntegrationAccountPartner[]> {
-    const client = new LogicAppsManagementClient(credentials, subscriptionId);
+export async function getAllPartners(credentials: IPartnerCredentials, subscriptionId: string, resourceGroup: string, integrationAccount: string): Promise<IntegrationAccountPartner[]> {
+    const client = new LogicAppsManagementClient(credentials, subscriptionId, credentials.environment?.resourceManagerEndpointUrl);
     addExtensionUserAgent(client);
 
     const partners = await client.integrationAccountPartners.list(resourceGroup, integrationAccount);
@@ -44,4 +45,8 @@ export async function getAllPartners(credentials: ServiceClientCredentials, subs
     }
 
     return partners;
+}
+
+export interface IPartnerCredentials extends ServiceClientCredentials {
+    environment?: AzureEnvironment;
 }

--- a/src/wizard/integration-account/agreements/agreementCreateStep.ts
+++ b/src/wizard/integration-account/agreements/agreementCreateStep.ts
@@ -12,7 +12,7 @@ import { IAgreementWizardContext } from "./createAgreementWizard";
 
 export class AgreementCreateStep extends AzureWizardExecuteStep<IAgreementWizardContext> {
     public async execute(wizardContext: IAgreementWizardContext): Promise<IAgreementWizardContext> {
-        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId, wizardContext.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         const newAgreement: IntegrationAccountAgreement = await client.integrationAccountAgreements.createOrUpdate(wizardContext.resourceGroup!.name!,

--- a/src/wizard/integration-account/agreements/agreementNameStep.ts
+++ b/src/wizard/integration-account/agreements/agreementNameStep.ts
@@ -41,7 +41,7 @@ export class AgreementNameStep extends AzureWizardPromptStep<IAgreementWizardCon
     }
 
     private async isNameAvailable(name: string, wizardContext: IAgreementWizardContext): Promise<boolean> {
-        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId, wizardContext.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         let agreements = await client.integrationAccountAgreements.list(wizardContext.resourceGroup!.name!, wizardContext.integrationAccountName);

--- a/src/wizard/integration-account/agreements/createAgreementWizard.ts
+++ b/src/wizard/integration-account/agreements/createAgreementWizard.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzureEnvironment } from "ms-rest-azure";
 import { BusinessIdentity, IntegrationAccount, IntegrationAccountPartner } from "azure-arm-logic/lib/models";
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IAzureNode, IAzureTreeItem, ILocationWizardContext, IResourceGroupWizardContext } from "vscode-azureextensionui";
 import { IntegrationAccountAgreementTreeItem } from "../../../tree/integration-account/IntegrationAccountAgreementTreeItem";
@@ -23,6 +24,7 @@ export interface IAgreementWizardContext extends ILocationWizardContext, IResour
     hostIdentity?: BusinessIdentity;
     guestPartner?: string;
     guestIdentity?: BusinessIdentity;
+    environment: AzureEnvironment;
 
     // Passing Data Around
     partners?: Map<string, IntegrationAccountPartner>;
@@ -53,7 +55,8 @@ export async function runNewAgreementWizard(integrationAccount: IntegrationAccou
             name: integrationAccount.id!.split("/").slice(-5, -4)[0]
         },
         subscriptionDisplayName: node.subscriptionDisplayName,
-        subscriptionId: node.subscriptionId
+        subscriptionId: node.subscriptionId,
+        environment: node.environment
     };
 
     // Create a new instance of an Azure wizard for creating Agreements.

--- a/src/wizard/integration-account/createIntegrationAccountWizard.ts
+++ b/src/wizard/integration-account/createIntegrationAccountWizard.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-
+import { AzureEnvironment } from "ms-rest-azure";
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IAzureNode, IAzureTreeItem, ILocationWizardContext, IResourceGroupWizardContext, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep } from "vscode-azureextensionui";
 import { IntegrationAccountTreeItem } from "../../tree/integration-account/IntegrationAccountTreeItem";
 import { IntegrationAccountCreateStep } from "./integrationAccountCreateStep";
@@ -13,6 +13,7 @@ export interface IIntegrationAccountWizardContext extends ILocationWizardContext
     integrationAccount?: IntegrationAccountTreeItem;
     integrationAccountName?: string;
     sku?: string;
+    environment: AzureEnvironment;
 }
 
 export async function runNewIntegrationAccountWizard(node: IAzureNode, showCreatingNode: (label: string) => void): Promise<IAzureTreeItem> {
@@ -34,7 +35,8 @@ export async function runNewIntegrationAccountWizard(node: IAzureNode, showCreat
     let wizardContext: IIntegrationAccountWizardContext = {
         credentials: node.credentials,
         subscriptionDisplayName: node.subscriptionDisplayName,
-        subscriptionId: node.subscriptionId
+        subscriptionId: node.subscriptionId,
+        environment: node.environment
     };
 
     // Create a new instance of an Azure wizard for creating Integration Accounts.

--- a/src/wizard/integration-account/integrationAccountCreateStep.ts
+++ b/src/wizard/integration-account/integrationAccountCreateStep.ts
@@ -12,7 +12,7 @@ import { IIntegrationAccountWizardContext } from "./createIntegrationAccountWiza
 
 export class IntegrationAccountCreateStep extends AzureWizardExecuteStep<IIntegrationAccountWizardContext> {
     public async execute(wizardContext: IIntegrationAccountWizardContext): Promise<IIntegrationAccountWizardContext> {
-        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId, wizardContext.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         const newIntegrationAccount: IntegrationAccount = await client.integrationAccounts.createOrUpdate(wizardContext.resourceGroup!.name!,

--- a/src/wizard/integration-account/integrationAccountNameStep.ts
+++ b/src/wizard/integration-account/integrationAccountNameStep.ts
@@ -52,7 +52,7 @@ export class IntegrationAccountNameStep extends AzureWizardPromptStep<IIntegrati
             resourceGroupName = wizardContext.resourceGroup!.name!;
         }
 
-        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId, wizardContext.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         let integrationAccounts = await client.integrationAccounts.listByResourceGroup(resourceGroupName);

--- a/src/wizard/integration-account/maps/createMapWizard.ts
+++ b/src/wizard/integration-account/maps/createMapWizard.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzureEnvironment } from "ms-rest-azure";
 import { IntegrationAccount } from "azure-arm-logic/lib/models";
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IAzureNode, IAzureTreeItem, ILocationWizardContext, IResourceGroupWizardContext } from "vscode-azureextensionui";
 import { IntegrationAccountMapTreeItem } from "../../../tree/integration-account/IntegrationAccountMapTreeItem";
@@ -15,6 +16,7 @@ export interface IMapWizardContext extends ILocationWizardContext, IResourceGrou
     map?: IntegrationAccountMapTreeItem;
     mapName?: string;
     mapType?: string;
+    environment: AzureEnvironment;
 }
 
 export async function runNewMapWizard(integrationAccount: IntegrationAccount, node: IAzureNode, showCreatingNode: (label: string) => void): Promise<IAzureTreeItem> {
@@ -38,7 +40,8 @@ export async function runNewMapWizard(integrationAccount: IntegrationAccount, no
             name: integrationAccount.id!.split("/").slice(-5, -4)[0]
         },
         subscriptionDisplayName: node.subscriptionDisplayName,
-        subscriptionId: node.subscriptionId
+        subscriptionId: node.subscriptionId,
+        environment: node.environment
     };
 
     // Create a new instance of an Azure wizard for creating Maps.

--- a/src/wizard/integration-account/maps/mapCreateStep.ts
+++ b/src/wizard/integration-account/maps/mapCreateStep.ts
@@ -12,7 +12,7 @@ import { IMapWizardContext } from "./createMapWizard";
 
 export class MapCreateStep extends AzureWizardExecuteStep<IMapWizardContext> {
     public async execute(wizardContext: IMapWizardContext): Promise<IMapWizardContext> {
-        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId, wizardContext.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         const newMap: IntegrationAccountMap = await client.integrationAccountMaps.createOrUpdate(wizardContext.resourceGroup!.name!,

--- a/src/wizard/integration-account/maps/mapNameStep.ts
+++ b/src/wizard/integration-account/maps/mapNameStep.ts
@@ -41,7 +41,7 @@ export class MapNameStep extends AzureWizardPromptStep<IMapWizardContext> {
     }
 
     private async isNameAvailable(name: string, wizardContext: IMapWizardContext): Promise<boolean> {
-        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId, wizardContext.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         let maps = await client.integrationAccountMaps.list(wizardContext.resourceGroup!.name!, wizardContext.integrationAccountName);

--- a/src/wizard/integration-account/partners/createPartnerWizard.ts
+++ b/src/wizard/integration-account/partners/createPartnerWizard.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzureEnvironment } from "ms-rest-azure";
 import { IntegrationAccount } from "azure-arm-logic/lib/models";
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IAzureNode, IAzureTreeItem, ILocationWizardContext, IResourceGroupWizardContext } from "vscode-azureextensionui";
 import { IntegrationAccountPartnerTreeItem } from "../../../tree/integration-account/IntegrationAccountPartnerTreeItem";
@@ -17,6 +18,7 @@ export interface IPartnerWizardContext extends ILocationWizardContext, IResource
     partnerName?: string;
     partnerQualifier?: string;
     partnerValue?: string;
+    environment: AzureEnvironment;
 }
 
 export async function runNewPartnerWizard(integrationAccount: IntegrationAccount, node: IAzureNode, showCreatingNode: (label: string) => void): Promise<IAzureTreeItem> {
@@ -41,7 +43,8 @@ export async function runNewPartnerWizard(integrationAccount: IntegrationAccount
             name: integrationAccount.id!.split("/").slice(-5, -4)[0]
         },
         subscriptionDisplayName: node.subscriptionDisplayName,
-        subscriptionId: node.subscriptionId
+        subscriptionId: node.subscriptionId,
+        environment: node.environment
     };
 
     // Create a new instance of an Azure wizard for creating Partners.

--- a/src/wizard/integration-account/partners/partnerCreateStep.ts
+++ b/src/wizard/integration-account/partners/partnerCreateStep.ts
@@ -12,7 +12,7 @@ import { IPartnerWizardContext } from "./createPartnerWizard";
 
 export class PartnerCreateStep extends AzureWizardExecuteStep<IPartnerWizardContext> {
     public async execute(wizardContext: IPartnerWizardContext): Promise<IPartnerWizardContext> {
-        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId, wizardContext.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         const newPartner: IntegrationAccountPartner = await client.integrationAccountPartners.createOrUpdate(wizardContext.resourceGroup!.name!,

--- a/src/wizard/integration-account/schemas/createSchemaWizard.ts
+++ b/src/wizard/integration-account/schemas/createSchemaWizard.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzureEnvironment } from "ms-rest-azure";
 import { IntegrationAccount } from "azure-arm-logic/lib/models";
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IAzureNode, IAzureTreeItem, ILocationWizardContext, IResourceGroupWizardContext } from "vscode-azureextensionui";
 import { IntegrationAccountSchemaTreeItem } from "../../../tree/integration-account/IntegrationAccountSchemaTreeItem";
@@ -13,6 +14,7 @@ export interface ISchemaWizardContext extends ILocationWizardContext, IResourceG
     integrationAccountName: string;
     schema?: IntegrationAccountSchemaTreeItem;
     schemaName?: string;
+    environment: AzureEnvironment;
 }
 
 export async function runNewSchemaWizard(integrationAccount: IntegrationAccount, node: IAzureNode, showCreatingNode: (label: string) => void): Promise<IAzureTreeItem> {
@@ -35,7 +37,8 @@ export async function runNewSchemaWizard(integrationAccount: IntegrationAccount,
             name: integrationAccount.id!.split("/").slice(-5, -4)[0]
         },
         subscriptionDisplayName: node.subscriptionDisplayName,
-        subscriptionId: node.subscriptionId
+        subscriptionId: node.subscriptionId,
+        environment: node.environment
     };
 
     // Create a new instance of an Azure wizard for creating Schemas.

--- a/src/wizard/integration-account/schemas/schemaCreateStep.ts
+++ b/src/wizard/integration-account/schemas/schemaCreateStep.ts
@@ -12,7 +12,7 @@ import { ISchemaWizardContext } from "./createSchemaWizard";
 
 export class SchemaCreateStep extends AzureWizardExecuteStep<ISchemaWizardContext> {
     public async execute(wizardContext: ISchemaWizardContext): Promise<ISchemaWizardContext> {
-        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId, wizardContext.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         const newSchema: IntegrationAccountSchema = await client.integrationAccountSchemas.createOrUpdate(wizardContext.resourceGroup!.name!,

--- a/src/wizard/integration-account/schemas/schemaNameStep.ts
+++ b/src/wizard/integration-account/schemas/schemaNameStep.ts
@@ -41,7 +41,7 @@ export class SchemaNameStep extends AzureWizardPromptStep<ISchemaWizardContext> 
     }
 
     private async isNameAvailable(name: string, wizardContext: ISchemaWizardContext): Promise<boolean> {
-        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId, wizardContext.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         let schemas = await client.integrationAccountSchemas.list(wizardContext.resourceGroup!.name!, wizardContext.integrationAccountName);

--- a/src/wizard/logic-app/LogicAppCreateStep.ts
+++ b/src/wizard/logic-app/LogicAppCreateStep.ts
@@ -11,7 +11,7 @@ import { IAzureLogicAppWizardContext } from "./createLogicApp";
 
 export class LogicAppCreateStep extends AzureWizardExecuteStep<IAzureLogicAppWizardContext> {
     public async execute(wizardContext: IAzureLogicAppWizardContext): Promise<IAzureLogicAppWizardContext> {
-        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId, wizardContext.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         const location = wizardContext.location!.name!;

--- a/src/wizard/logic-app/LogicAppNameStep.ts
+++ b/src/wizard/logic-app/LogicAppNameStep.ts
@@ -53,7 +53,7 @@ export class LogicAppNameStep extends AzureWizardPromptStep<IAzureLogicAppWizard
             resourceGroupName = wizardContext.resourceGroup!.name!;
         }
 
-        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = new LogicAppsManagementClient(wizardContext.credentials, wizardContext.subscriptionId, wizardContext.environment.resourceManagerEndpointUrl);
         addExtensionUserAgent(client);
 
         let workflows = await client.workflows.listByResourceGroup(resourceGroupName);

--- a/src/wizard/logic-app/createLogicApp.ts
+++ b/src/wizard/logic-app/createLogicApp.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzureEnvironment } from "ms-rest-azure";
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IAzureNode, IAzureTreeItem, ILocationWizardContext, IResourceGroupWizardContext, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep } from "vscode-azureextensionui";
 import { LogicAppTreeItem } from "../../tree/logic-app/LogicAppTreeItem";
 import { LogicAppCreateStep } from "./LogicAppCreateStep";
@@ -11,6 +12,7 @@ import { LogicAppNameStep } from "./LogicAppNameStep";
 export interface IAzureLogicAppWizardContext extends ILocationWizardContext, IResourceGroupWizardContext {
     logicApp?: LogicAppTreeItem;
     workflowName?: string;
+    environment: AzureEnvironment;
 }
 
 export async function createLogicApp(node: IAzureNode, showCreatingNode: (label: string) => void): Promise<IAzureTreeItem> {
@@ -31,7 +33,8 @@ export async function createLogicApp(node: IAzureNode, showCreatingNode: (label:
     let wizardContext: IAzureLogicAppWizardContext = {
         credentials: node.credentials,
         subscriptionDisplayName: node.subscriptionDisplayName,
-        subscriptionId: node.subscriptionId
+        subscriptionId: node.subscriptionId,
+        environment: node.environment
     };
 
     // Create a new instance of an Azure wizard for creating Logic Apps.


### PR DESCRIPTION
Resubmitting PR (previous PR #150 closed while I sorted things out).

I was able to update `vscode-azureextensionui` to v0.17.1 which is the version the fix for Azure Government was introduced. I coupled the update with my previous changes where the `baseUri` parameter is passed into `LogicAppsManagementClient()` and got to a 95% working solution.

I have tested changes on both Azure Commercial and Azure Government. The following are the results.

* **FIXED**: Create Logic App command working for Azure Government
* **FIXED**: Promote command working for Azure Government
* **FIXED**: Enable, Disable commands working for Azure Government
* **FIXED**: Delete command working for Azure Government
* **FIXED**: Create Integration Account working for Azure Government
* **FIXED**: Create Integration Account SubChildren (ie: Partners) for Azure Government
* **NEEDS TEST**: Add Build Definition to Project
* **NEEDS TEST**: Open in Monitoring View
* **ERROR**: openInDesigner throws subscriptionId error. Using `ms-rest.ServiceClientCredentials.signRequest()` instead of the `LogicAppsManagementClient`.
