### PR TITLE
Update draft to Draft to support case-sensitive file systems

### DIFF
--- a/src/utils/logic-app/designerUtils.ts
+++ b/src/utils/logic-app/designerUtils.ts
@@ -194,7 +194,7 @@ export function getWebviewContentForDesigner({ authorization, callbacks, definit
                     "@uifabric/styling/lib": "@uifabric/styling",
                     "@uifabric/utilities/lib": "@uifabric/utilities",
                     "core/main": "core.designer.min",
-                    "draft-js": "draft.min",
+                    "draft-js": "Draft.min",
                     "fuse": "fuse.min",
                     "immutable": "immutable.min",
                     "localforage": "localforage.min",


### PR DESCRIPTION
Draft needs to be capitalized here since the file is actually `Draft.min.js`. This will help this extension support GitHub Codespaces. I'm not sure where the Preview extension code is but please make that change there.